### PR TITLE
Change the way to check the form in FormSaveData2ContentEntry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Changelog
 
 2.3.0b4 ~ unreleased
 --------------------
+- In FormSaveData2ContentEntry/getForm change the way to check the form: 
+  right now is not by portal_type but by interface [lucabel]
 
 2.3.0b3 ~ 2012-12-18
 --------------------

--- a/uwosh/pfg/d2c/content/dataentry.py
+++ b/uwosh/pfg/d2c/content/dataentry.py
@@ -11,6 +11,7 @@ from uwosh.pfg.d2c.config import PROJECTNAME
 from Products.ATContentTypes.content.base import ATCTContent
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
 from uwosh.pfg.d2c.interfaces import IFormSaveData2ContentEntry
+from Products.PloneFormGen.interfaces import IPloneFormGenForm
 from zope.interface import implements
 
 from Products.CMFCore import permissions
@@ -46,7 +47,7 @@ class FormSaveData2ContentEntry(ATCTContent):
             adapter = self.getParentNode()
 
         form = adapter.getParentNode()
-        if getattr(form, 'portal_type', None) != 'FormFolder':
+        if not IPloneFormGenForm.providedBy(form):
             form = None
         return form
 


### PR DESCRIPTION
I think it's useful, in case people need to create an extention archetype from FormFolder class, to check the form by interface and not by portal type.
