### PR TITLE
make sure we don't acquire Description from the parent

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.4.6 ~ unreleased
 ------------------
 
-- nothing yet
+- Fix bug where viewing a data entry led to an 'Insufficient Privileges'
+  screen if the user did not have permission to view the container.
+  [davisagli]
 
 2.4.5 ~ 2014-09-18
 ------------------

--- a/uwosh/pfg/d2c/content/dataentry.py
+++ b/uwosh/pfg/d2c/content/dataentry.py
@@ -119,6 +119,10 @@ class FormSaveData2ContentEntry(ATCTContent):
         else:
             return self.getId()
 
+    security.declareProtected(permissions.View, 'Description')
+    def Description(self):
+        return ''
+
     security.declareProtected(permissions.View, 'getValue')
     def getValue(self, field, default=None, **kwargs):
         """


### PR DESCRIPTION
This makes it possible to share data entries with a user via the sharing tab. Before, it would acquire Description from the parent, determine that the user doesn't have permission to view it, and throw Unauthorized
