### PR TITLE
make sure attachments get stored as blobs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,11 @@ Changelog
 - Added German translation.
   [acsr]
 
+- Fix bug where file attachments were created as non-blob files
+  stored in a blob field. This fixes
+  https://github.com/collective/uwosh.pfg.d2c/issues/20
+  [davisagli]
+
 
 2.4.7 ~ unreleased
 ------------------

--- a/uwosh/pfg/d2c/content/savedataadapter.py
+++ b/uwosh/pfg/d2c/content/savedataadapter.py
@@ -256,10 +256,7 @@ class FormSaveData2ContentAdapter(ATFolder, FormActionAdapter):
                     value = REQUEST.form.get('%s_amount' % name)
 
             if field.__class__ == FileField:
-                fieldobj = form.findFieldObjectByName(name)
-                isImField = fieldobj and fieldobj.getField('isImage')
-                if isImField and isImField.get(fieldobj):
-                    field = obj.getField(name)
+                field = obj.getField(name)
                 name += '_file'
                 value = REQUEST.form.get(name)
                 if hasattr(value, 'filename') and value.filename:


### PR DESCRIPTION
This fixes #20 (well, it doesn't fix downloading files that were stored before this fix, but it makes sure new ones get stored correctly).